### PR TITLE
Fonts CORS error: updated baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # Site settings
-baseurl = "https://berlin2019.satrdays.org/"
+baseurl = "https://berlin2020.satrdays.org/"
 languageCode = "en-us"
 title = "satRday Berlin"
 theme = ["hugo-satrdays-theme", "hugo-agency-theme"]
@@ -34,7 +34,7 @@ googleAnalytics = ""
   meta_title = "satRday Berlin"
   meta_image = "/img/flyer.jpg"
   meta_description = "A conference for R users in Berlin"
-  meta_url = "https://berlin2019.satrdays.org/"
+  meta_url = "https://berlin2020.satrdays.org/"
 
   # 404 error customization
   [params.error404]

--- a/content/impressum.html
+++ b/content/impressum.html
@@ -1,58 +1,73 @@
 <!DOCTYPE html>
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+
 <head>
-  {{ partial "head.html" . }}
+    {{ partial "head.html" . }}
 </head>
-  <body id="page-top" class="index">
+
+<body id="page-top" class="index">
     {{ partial "nav.html" . }}
-    
+
     <section id="scholarships" {{ if .Site.Params.diversity.bg }} class="bg-light-gray" {{ end }}>
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">Impressum</h2>
                 </div>
-<h1>Legal Disclosure</h1>
-Information in accordance with Section 5 TMG
-<br><br>Tieckstr. 40<br>c/o Olga Maslovskaya<br>10115 Berlin<br>
-<h2>Represented by</h2>
-Jakob Graff, Olga Maslovskaya, Noa Tamir<br><br>
-<h2>Contact Information</h2>
-Telephone: +4917647697674<br>E-Mail: <a href="mailto:satrday.berlin@gmail.com">satrday.berlin@gmail.com</a><br>Internet address: <a href="https://berlin2019.satrdays.org/" target="_blank">https://berlin2019.satrdays.org/</a><br>
-<h2>Register entry</h2>
-Entry in: Vereinsregister<br>Register Number: VR 37258 B<br>Register Court: Amtsgericht Charlottenburg<br><br>
-<h2>Disclaimer</h2>
-Accountability for content<br>
-The contents of our pages have been created with the utmost care. However, we cannot guarantee the contents'
-accuracy, completeness or topicality. According to statutory provisions, we are furthermore responsible for 
-our own content on these web pages. In this matter, please note that we are not obliged to monitor 
-the transmitted or saved information of third parties, or investigate circumstances pointing to illegal activity. 
-Our obligations to remove or block the use of information under generally applicable laws remain unaffected by this as per 
-§§ 8 to 10 of the Telemedia Act (TMG).
+                <h1>Legal Disclosure</h1>
+                Information in accordance with Section 5 TMG
+                <br><br>Tieckstr. 40<br>c/o Olga Maslovskaya<br>10115 Berlin<br>
+                <h2>Represented by</h2>
+                Jakob Graff, Olga Maslovskaya, Noa Tamir<br><br>
+                <h2>Contact Information</h2>
+                Telephone: +4917647697674<br>E-Mail: <a
+                    href="mailto:satrday.berlin@gmail.com">satrday.berlin@gmail.com</a><br>Internet address: <a
+                    href="https://berlin2020.satrdays.org/" target="_blank">https://berlin2020.satrdays.org/</a><br>
+                <h2>Register entry</h2>
+                Entry in: Vereinsregister<br>Register Number: VR 37258 B<br>Register Court: Amtsgericht
+                Charlottenburg<br><br>
+                <h2>Disclaimer</h2>
+                Accountability for content<br>
+                The contents of our pages have been created with the utmost care. However, we cannot guarantee the
+                contents'
+                accuracy, completeness or topicality. According to statutory provisions, we are furthermore responsible
+                for
+                our own content on these web pages. In this matter, please note that we are not obliged to monitor
+                the transmitted or saved information of third parties, or investigate circumstances pointing to illegal
+                activity.
+                Our obligations to remove or block the use of information under generally applicable laws remain
+                unaffected by this as per
+                §§ 8 to 10 of the Telemedia Act (TMG).
 
-<br><br>Accountability for links<br>
-Responsibility for the content of 
-external links (to web pages of third parties) lies solely with the operators of the linked pages. No violations were 
-evident to us at the time of linking. Should any legal infringement become known to us, we will remove the respective 
-link immediately.<br><br>Copyright<br> Our web pages and their contents are subject to German copyright law. Unless 
-expressly permitted by law, every form of utilizing, reproducing or processing 
-works subject to copyright protection on our web pages requires the prior consent of the respective owner of the rights. 
-Individual reproductions of a work are only allowed for private use. 
-The materials from these pages are copyrighted and any unauthorized use may violate copyright laws.
+                <br><br>Accountability for links<br>
+                Responsibility for the content of
+                external links (to web pages of third parties) lies solely with the operators of the linked pages. No
+                violations were
+                evident to us at the time of linking. Should any legal infringement become known to us, we will remove
+                the respective
+                link immediately.<br><br>Copyright<br> Our web pages and their contents are subject to German copyright
+                law. Unless
+                expressly permitted by law, every form of utilizing, reproducing or processing
+                works subject to copyright protection on our web pages requires the prior consent of the respective
+                owner of the rights.
+                Individual reproductions of a work are only allowed for private use.
+                The materials from these pages are copyrighted and any unauthorized use may violate copyright laws.
 
-<br><br>
-<i>Quelle: </i><a href="http://www.translate-24h.de" target="_blank">translate-24h Englisch Übersetzungen</a> <br><br>
+                <br><br>
+                <i>Quelle: </i><a href="http://www.translate-24h.de" target="_blank">translate-24h Englisch
+                    Übersetzungen</a> <br><br>
 
-</section>
-    
-{{ if .Site.Params.footer.enable }}
-  {{ partial "footer.html" . }}
-{{ end }}
+    </section>
 
-{{ if .Site.Params.portfolio.enable }}
-  {{ partial "modals.html" . }}
-{{ end }}
+    {{ if .Site.Params.footer.enable }}
+    {{ partial "footer.html" . }}
+    {{ end }}
 
-{{ partial "js.html" . }}
+    {{ if .Site.Params.portfolio.enable }}
+    {{ partial "modals.html" . }}
+    {{ end }}
+
+    {{ partial "js.html" . }}
 </body>
+
 </html>

--- a/content/privacy.html
+++ b/content/privacy.html
@@ -71,7 +71,7 @@
 <p>Germany</p>
 <p>Phone: +4917647697674</p>
 <p>Email: satrday.berlin@gmail.com</p>
-<p>Website: https://berlin2019.satrdays.org/</p>
+<p>Website: https://berlin2020.satrdays.org/</p>
 
 <h4>3. Collection of general data and information</h4>
 <p>The website of the satRday Berlin e.V. collects a series of general data and information when a data subject or automated system calls up the website. This general data and information are stored in the server log files. Collected may be (1) the browser types and versions used, (2) the operating system used by the accessing system, (3) the website from which an accessing system reaches our website (so-called referrers), (4) the sub-websites, (5) the date and time of access to the Internet site, (6) an Internet protocol address (IP address), (7) the Internet service provider of the accessing system, and (8) any other similar data and information that may be used in the event of attacks on our information technology systems.</p>


### PR DESCRIPTION
Font Awesome fonts are blocked in Firefox due to baseURL missmatch (set to berlin2019).
Also updated berlin2019 in impressum, theme & privacy.